### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled command line

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import qrcode
 import netifaces
 import os
 import sqlite3
-
+import shlex
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///tasks.db'
 # Add this line to suppress the FSADeprecationWarning
@@ -154,7 +154,8 @@ def add():
         db.session.commit()
         generate_code(code)
         # Annoncer automatiquement le ticket
-        os.system(f'say "Nouveau ticket disponible: {name}"')
+        safe_name = shlex.quote(name)
+        os.system(f'say "Nouveau ticket disponible: {safe_name}"')
         return redirect(url_for('index'))
     return render_template('add.html', users=users, tickets=tickets)
 


### PR DESCRIPTION
Potential fix for [https://github.com/toto789520/activity-screening/security/code-scanning/3](https://github.com/toto789520/activity-screening/security/code-scanning/3)

To fix the problem, we should avoid passing user input directly to the `os.system` call. Instead, we can use a predefined allowlist of acceptable commands or sanitize the input to ensure it does not contain any malicious content. In this case, we can use the `shlex.quote` function to safely escape the user input before including it in the shell command.

- Import the `shlex` module.
- Use `shlex.quote` to sanitize the `name` variable before using it in the `os.system` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
